### PR TITLE
Add disconnect method for ServerCommandRunners,

### DIFF
--- a/src/Contracts/ServerCommandRunner.php
+++ b/src/Contracts/ServerCommandRunner.php
@@ -153,4 +153,11 @@ interface ServerCommandRunner {
      * @throws \DSG\SquadRCON\Exceptions\RConException
      */
     function adminSetNextMap(string $map) : bool;
+
+    /**
+     * Disconnects the runner from any squad server instance.
+     *
+     * @return void
+     */
+    function disconnect() : void;
 }

--- a/src/Runners/SquadCommandRunner.php
+++ b/src/Runners/SquadCommandRunner.php
@@ -240,4 +240,16 @@ class SquadCommandRunner implements ServerCommandRunner {
         $response = $this->sourceQuery->Rcon($cmd . ' ' . $param);
         return substr($response, 0, strlen($expected)) == $expected;
     }
+
+    /**
+     * Disconnects the runner from any squad server instance.
+     *
+     * @return void
+     */
+    function disconnect() : void
+    {
+        if ($this->sourceQuery) {
+            $this->sourceQuery->Disconnect();
+        }
+    }
 }

--- a/src/SquadServer.php
+++ b/src/SquadServer.php
@@ -14,7 +14,7 @@ class SquadServer
 {
     const SQUAD_SOCKET_TIMEOUT_SECONDS = 0.5;
 
-    /** @var Ser */
+    /** @var ServerCommandRunner */
     private ServerCommandRunner $runner;
 
     /**
@@ -33,6 +33,16 @@ class SquadServer
         }
 
         $this->runner = $runner;
+    }
+
+    public function __destruct()
+    {
+        $this->disconnect();
+    }
+
+    public function disconnect() : void
+    {
+        $this->runner->disconnect();
     }
 
     /**

--- a/tests/Feature/LiveSquadServerTest.php
+++ b/tests/Feature/LiveSquadServerTest.php
@@ -174,4 +174,14 @@ class LiveSquadServerTest extends \DSG\SquadRCON\Tests\TestCase {
     {
         $this->assertTrue($this->squadServer->setPassword('secret'));
     }
+
+    /**
+     * Verifies the disconnect method works without any exception
+     * 
+     * @return void
+     */
+    public function test_squad_server_disconnect()
+    {
+        $this->assertNull($this->squadServer->disconnect());
+    }
 }

--- a/tests/Feature/SquadServerTest.php
+++ b/tests/Feature/SquadServerTest.php
@@ -284,4 +284,14 @@ class SquadServerTest extends \DSG\SquadRCON\Tests\TestCase {
     {
         $this->assertTrue($this->squadServer->banById(1, '1h', 'Test'));
     }
+
+    /**
+     * Verifies the disconnect method works without any exception
+     * 
+     * @return void
+     */
+    public function test_squad_server_disconnect()
+    {
+        $this->assertNull($this->squadServer->disconnect());
+    }
 }

--- a/tests/Runners/TestingCommandRunner.php
+++ b/tests/Runners/TestingCommandRunner.php
@@ -202,4 +202,14 @@ class TestingCommandRunner implements ServerCommandRunner {
     {
         return true;
     }
+
+    /**
+     * Disconnects the runner from any squad server instance.
+     *
+     * @return void
+     */
+    function disconnect() : void
+    {
+        return;
+    }
 }


### PR DESCRIPTION
Add a disconnect method to the SquadServer and call it in the `__destruct()` magic method.
Fix PHPDoc