### PR TITLE
Rework Squad-Leader implementation

### DIFF
--- a/src/Data/Population.php
+++ b/src/Data/Population.php
@@ -89,4 +89,22 @@ class Population
         /* Return null in case nothing has been found */
         return null;
     }
+    /**
+     * Determines if data provided by ListPlayers is in
+     * sync with data provided by ListSquads.
+     *
+     * @return bool
+     */
+    public function isSynced() : bool
+    {
+        foreach ($this->getTeams() as $team) {
+            foreach ($team->getSquads() as $squad) {
+                if (is_null($squad->getCreator())) {
+                    return false;
+                }
+            }
+        }
+        
+        return true;
+    }
 }

--- a/src/Data/Squad.php
+++ b/src/Data/Squad.php
@@ -112,10 +112,9 @@ class Squad
     /**
      * Get the Player that created this Squad instance.
      * 
-     * @return Player
-     * @throws \Exception If the creator can not be found
+     * @return Player|null
      */
-    public function getCreator() : Player
+    public function getCreator() : ?Player
     {
         foreach ($this->players as $player) {
             if ($player->getSteamId() === $this->creator) {
@@ -123,7 +122,7 @@ class Squad
             }
         }
         
-        throw new \Exception('Squad creator could not be found! Squad ID: ' . $this->getId() . ', Creator ID: ' . $this->creator);
+        return null;
     }
 
     /**

--- a/src/SquadServer.php
+++ b/src/SquadServer.php
@@ -46,12 +46,20 @@ class SquadServer
     }
 
     /**
+     * Retrieve and create a server Population object. This will
+     * contain Squads and Players properly structured and linked.
+     * In cases players join/leave between booth calls, the commands
+     * will be retried until the retrieved data is in sync or $maxTries 
+     * is exhausted.
+     *
      * @return Team[]
      * @throws \DSG\SquadRCON\Exceptions\RConException|\Exception
      */
     public function serverPopulation(int $maxTries = 3) : Population
     {
+        /* Initialize some runtime variables required to keep track of what we are doing here, TODO: needs refactoring */
         $try = 0;
+        $population = null;
         
         /* Make sure we have a Population object that is in sync, repeat otherwise */
         while (is_null($population) || !$population->isSynced()) {

--- a/src/SquadServer.php
+++ b/src/SquadServer.php
@@ -47,15 +47,29 @@ class SquadServer
 
     /**
      * @return Team[]
-     * @throws \DSG\SquadRCON\Exceptions\RConException
+     * @throws \DSG\SquadRCON\Exceptions\RConException|\Exception
      */
-    public function serverPopulation() : Population
+    public function serverPopulation(int $maxTries = 3) : Population
     {
-        /* Get the current Teams and their Squads */
-        $population = new Population($this->listSquads());
+        $try = 0;
+        
+        /* Make sure we have a Population object that is in sync, repeat otherwise */
+        while (is_null($population) || !$population->isSynced()) {
+            /* Do not repeat if max tries are exhausted */
+            if ($try >= $maxTries) {
+                throw new \Exception('Could not sync population object. Exhausted max tries of ' . $maxTries);
+            }
+            
+            /* Get the current Teams and their Squads */
+            $population = new Population($this->listSquads());
 
-        /* Get the currently connected players, feed listSquads output to reference Teams/Squads */
-        $this->listPlayers($population);
+            /* Get the currently connected players, feed listSquads output to reference Teams/Squads */
+            $this->listPlayers($population);
+            
+            /* Use up another try */
+            ++$try;
+        }
+        
 
         return $population;
     }


### PR DESCRIPTION
- Allow Squad to return null for leader if none is found
- Make sure Population data is in sync and all squads havea  leader (i.e. sl left between RCON calls)